### PR TITLE
fix delete controller

### DIFF
--- a/backend/controllers/contactController.js
+++ b/backend/controllers/contactController.js
@@ -59,8 +59,8 @@ function updateAll(req, res) {
           last_name: req.body.last_name,
           birthday: new Date(req.body.birthday),
           marital_status: req.body.marital_status,
-          is_employed: req.body.is_employed,
-          is_parent: req.body.is_parent,
+          is_employed: req.body.is_employed === "Employed",
+          is_parent: req.body.is_parent === "Parent",
         })
       );
 
@@ -165,42 +165,62 @@ function deleteOne(req, res) {
   db.contact
     .findByPk(userId)
     .then((userInstance) => {
+      console.log("====");
+
+      console.log(userInstance);
+      console.log("====");
+
       return Promise.all([
-        userInstance
-          .getEmployment_detail()
-          .then((employmentInstance) => employmentInstance.destroy()),
+        userInstance.destroy(),
+
+        userInstance.getEmployment_detail().then((employmentInstance) => {
+          employmentInstance?.destroy();
+        }),
 
         userInstance
           .getParenthood_detail()
-          .then((parentHoodInstance) => parentHoodInstance.destroy()),
+          .then((parentHoodInstance) => parentHoodInstance?.destroy()),
 
         userInstance.getEmails().then((emailInstances) => {
           emailInstances.map((emailInstance) => {
-            return emailInstance.destroy();
+            return emailInstance?.destroy();
           });
         }),
 
         userInstance.getContact_phone_numbers().then((numberInstances) => {
           numberInstances.map((numberInstance) => {
-            return numberInstance.destroy();
+            return numberInstance?.destroy();
           });
         }),
 
         userInstance.getCategories().then((categoryInstances) => {
           categoryInstances.map((categoryInstance) => {
-            return categoryInstance.destroy();
+            return categoryInstance?.destroy();
           });
         }),
 
         userInstance.getHobbies().then((hobbyInstances) => {
           hobbyInstances.map((hobbyInstance) => {
-            return hobbyInstance.destroy();
+            return hobbyInstance?.destroy();
           });
         }),
       ]);
     })
-    .then(res.send("Contact deleted"))
-    .catch((err) => console.log(err));
+    .then((done) => {
+      // console.log("====");
+      // console.log(done);
+      // console.log("====");
+      res.send("Contact deleted");
+    })
+    .catch((err) => {
+      res.status(err.status || 500).send({
+        status: "error",
+        error: {
+          message: err.message || "cannot delete contact",
+        },
+      });
+      console.log(err);
+    });
 }
 
 function findByName(req, res) {
@@ -233,8 +253,8 @@ function add(req, res) {
           last_name: req.body.last_name,
           birthday: new Date(req.body.birthday),
           marital_status: req.body.marital_status,
-          is_employed: true,
-          is_parent: true,
+          is_employed: req.body.is_employed === "Employed",
+          is_parent: req.body.is_Parent === "Parent",
         },
         transaction: t,
       })

--- a/backend/db/models/contact.js
+++ b/backend/db/models/contact.js
@@ -21,7 +21,7 @@ module.exports = (sequelize, DataTypes) => {
       is_parent: { type: DataTypes.BOOLEAN, allowNull: false },
       is_employed: { type: DataTypes.BOOLEAN, allowNull: false },
     },
-    { freezeTableName: true, underscored: true }
+    { freezeTableName: true, underscored: true, onDelete: "cascade" }
   );
 
   contact.associate = (models) => {

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,5 +1,5 @@
 var express = require("express");
-var router = express.Router();
+var router = express.Router(); // gets an instance of express router
 const controllers = require("../controllers");
 
 const { contactController } = controllers;


### PR DESCRIPTION
Fix delete controller
- add onDelete: 'cascade' to model to stop foreign key constraint from preventing associated models to be deleted
- return a rejected promise to prevent .catch from not catching deletion related errors
- improve error message 
- add optional chaining to short circuit 'cannot read null errors' when attempting to read db