### PR TITLE
fix: allow employment details to be null in model and migration

### DIFF
--- a/backend/db/migrations/20231025100341-create-employment-detail.js
+++ b/backend/db/migrations/20231025100341-create-employment-detail.js
@@ -22,15 +22,15 @@ module.exports = {
       },
       company_name: {
         type: Sequelize.STRING,
-        allowNull: false,
+        allowNull: true,
       },
       company_industry: {
         type: Sequelize.STRING,
-        allowNull: false,
+        allowNull: true,
       },
       role: {
         type: Sequelize.STRING,
-        allowNull: false,
+        allowNull: true,
       },
       created_at: {
         allowNull: false,

--- a/backend/db/models/employment_detail.js
+++ b/backend/db/models/employment_detail.js
@@ -4,9 +4,9 @@ module.exports = (sequelize, DataTypes) => {
   const employment_detail = sequelize.define(
     "employment_detail",
     {
-      company_name: { type: DataTypes.STRING, allowNull: false },
-      company_industry: { type: DataTypes.STRING, allowNull: false },
-      role: { type: DataTypes.STRING, allowNull: false },
+      company_name: { type: DataTypes.STRING, allowNull: true },
+      company_industry: { type: DataTypes.STRING, allowNull: true },
+      role: { type: DataTypes.STRING, allowNull: true },
       contact_id: {
         type: DataTypes.INTEGER,
         references: {


### PR DESCRIPTION
Employment model and migration file did not allow for certain fields (company, role and company industry) to be null.  This fields need to be null as the contact can be unemployed and leaving these fields ad null causes sequelize validation errors and sequelize transactions to fail. this is now fixed to allowNull: true