### PR TITLE
fix horizontal overflow caused by translating navbar right actions

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12,13 +12,14 @@
 }
 html {
   scrollbar-gutter: stable;
+  overflow-x: hidden; /* prevent horizontal scroll when applying translateX to rightActions on navbar */
 }
 
 body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   margin: 0;
-  /* width: calc(100% - var(--removed-body-scroll-bar-size, 0px)); */
+  overflow-x: hidden; /* prevent horizontal scroll when applying translateX to rightActions on navbar */
 }
 
 body[style] {


### PR DESCRIPTION
- applied overflow-x hidden to stop horizontal scroll bar from appearing as a result of translating navbar right actions to the right of the screen